### PR TITLE
Fix invalid reset of URL variable

### DIFF
--- a/trojans/csd-wrapper.sh
+++ b/trojans/csd-wrapper.sh
@@ -35,7 +35,6 @@ BINS=("cscan" "cstub" "cnotify")
 # parsing command line
 shift
 
-URL=
 TICKET=
 STUB=
 GROUP=


### PR DESCRIPTION
The URL variable is constructed from the CSD_HOSTNAME at the beginning of the script.
However, prior to parsing the command line, it was reset to empty value.